### PR TITLE
Added conditional to support sphinx gallery pre and post v0.11

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -2328,13 +2328,18 @@ def depart_admonition_text(self, node):
 
 
 def depart_gallery_html(self, node):
-    # keep temporary support for old sphinx_gallery versions < 0.11.0 by discovering the version at runtime
+    # keep temporary support for old sphinx_gallery versions < 0.11.0 by
+    # discovering the version at runtime
     import importlib.metadata
-    try: # avoid hard dependencies to non-standard library packages for this temporary fix
-        import packaging.version
-        have_legacy_sphinx_gallery = packaging.version.parse(importlib.metadata.version('sphinx_gallery')) < packaging.version.parse('0.11.0')
+    try:
+        # avoid hard dependencies to non-standard library packages for this
+        # temporary fix
+        from packaging.version import parse
+        sg_version = importlib.metadata.version('sphinx_gallery')
+        have_legacy_sphinx_gallery = parse(sg_version) < parse('0.11.0')
     except (ModuleNotFoundError, importlib.metadata.PackageNotFoundError):
-        have_legacy_sphinx_gallery = False # keep default behaviour in case errors arise
+        # keep default behaviour in case errors arise
+        have_legacy_sphinx_gallery = False
     if not have_legacy_sphinx_gallery:
         self.body.append('<div class="sphx-glr-thumbnails">\n')
     for title, uri, filename, tooltip in node['entries']:
@@ -2355,7 +2360,11 @@ def depart_gallery_html(self, node):
 </div>""" if have_legacy_sphinx_gallery else """\
 <div class="sphx-glr-thumbcontainer"{tooltip}>
   <img alt="" src="{filename}" />
-  <p><a class="reference internal" href="{uri}"><span class="std std-ref">{title}</span></a></p>
+  <p>
+    <a class="reference internal" href="{uri}">
+      <span class="std std-ref">{title}</span>
+    </a>
+  </p>
   <div class="sphx-glr-thumbnail-title">{title}</div>
 </div>
 """).format(

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -2328,23 +2328,42 @@ def depart_admonition_text(self, node):
 
 
 def depart_gallery_html(self, node):
-    self.body.append('<div class="sphx-glr-thumbnails">\n')
+    import importlib.metadata
+    import packaging.version
+    have_legacy_sphinx_gallery = packaging.version.parse(importlib.metadata.version('sphinx_gallery')) < packaging.version.parse('0.11.0')
+    if not have_legacy_sphinx_gallery:
+        self.body.append('<div class="sphx-glr-thumbnails">\n')
     for title, uri, filename, tooltip in node['entries']:
         if tooltip:
             tooltip = ' tooltip="{}"'.format(html.escape(tooltip))
-        self.body.append("""\
+        self.body.append(("""\
+<div class="sphx-glr-thumbcontainer"{tooltip}>
+  <div class="figure align-center">
+    <img alt="thumbnail" src="{filename}" />
+    <p class="caption">
+      <span class="caption-text">
+        <a class="reference internal" href="{uri}">
+          <span class="std std-ref">{title}</span>
+        </a>
+      </span>
+    </p>
+  </div>
+</div>""" if have_legacy_sphinx_gallery else """\
 <div class="sphx-glr-thumbcontainer"{tooltip}>
   <img alt="" src="{filename}" />
   <p><a class="reference internal" href="{uri}"><span class="std std-ref">{title}</span></a></p>
   <div class="sphx-glr-thumbnail-title">{title}</div>
 </div>
-""".format(
+""").format(
             uri=html.escape(uri),
             title=html.escape(title),
             tooltip=tooltip,
             filename=html.escape(filename),
         ))
-    self.body.append('</div>\n')
+    if have_legacy_sphinx_gallery:
+        self.body.append('<div class="sphx-glr-clear"></div>\n')
+    else:
+        self.body.append('</div>\n')
 
 
 def do_nothing(self, node):

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -2328,9 +2328,13 @@ def depart_admonition_text(self, node):
 
 
 def depart_gallery_html(self, node):
+    # keep temporary support for old sphinx_gallery versions < 0.11.0 by discovering the version at runtime
     import importlib.metadata
-    import packaging.version
-    have_legacy_sphinx_gallery = packaging.version.parse(importlib.metadata.version('sphinx_gallery')) < packaging.version.parse('0.11.0')
+    try: # avoid hard dependencies to non-standard library packages for this temporary fix
+        import packaging.version
+        have_legacy_sphinx_gallery = packaging.version.parse(importlib.metadata.version('sphinx_gallery')) < packaging.version.parse('0.11.0')
+    except (ModuleNotFoundError, importlib.metadata.PackageNotFoundError):
+        have_legacy_sphinx_gallery = False # keep default behaviour in case errors arise
     if not have_legacy_sphinx_gallery:
         self.body.append('<div class="sphx-glr-thumbnails">\n')
     for title, uri, filename, tooltip in node['entries']:


### PR DESCRIPTION
Thanks @mgeier for all the great work you put into nbsphinx!
If I understood https://github.com/sphinx-gallery/sphinx-gallery/issues/984 correctly, [this merge request](https://github.com/spatialaudio/nbsphinx/pull/666) would fix https://github.com/spatialaudio/nbsphinx/issues/655, and the only thing missing is backwards compatibility with sphinx-gallery pre v0.11.
As the solution is temporary anyway, would a simple conditional not suffice? It worked for my case in environments using sphinx-gallery 0.10.1 and sphinx-gallery 0.11.1 (The results did not look identical, but the behaviour for 0.11.1 was greatly improved...)
I would love to see this issue fixed without having to pin the version of sphinx gallery.